### PR TITLE
Fix text input focus loss in searchbar/textfield

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -857,6 +857,9 @@ iui_textfield_result iui_textfield_with_selection(
     if (!ctx->current_window || !buffer || !state || size == 0)
         return result;
 
+    /* Register this text field for per-frame tracking */
+    iui_register_textfield(ctx, buffer);
+
     /* Default options if NULL */
     iui_textfield_options opts = {0};
     if (options)

--- a/src/searchbar.c
+++ b/src/searchbar.c
@@ -29,6 +29,9 @@ iui_search_bar_result iui_search_bar_ex(iui_context *ctx,
     if (!ctx || !ctx->current_window || !buffer || !cursor || size == 0)
         return result;
 
+    /* Register this text field for per-frame tracking */
+    iui_register_textfield(ctx, buffer);
+
     /* Default icons */
     const char *lead_icon = leading_icon ? leading_icon : "search";
     bool has_text = (buffer[0] != '\0');
@@ -344,8 +347,9 @@ bool iui_search_view_begin(iui_context *ctx,
                            ctx->colors.surface_container_high,
                            ctx->renderer.user);
 
-    /* Auto-focus the search field */
+    /* Auto-focus the search field and register for tracking */
     ctx->focused_edit = search->query;
+    iui_register_textfield(ctx, search->query);
 
     /* Handle text input */
     iui_process_text_input(ctx, search->query, sizeof(search->query),


### PR DESCRIPTION
Text input components were losing focus every frame because they failed to register with the field tracking system. The tracking system clears ctx->focused_edit at frame end for unregistered buffers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed focus loss in text inputs by registering buffers with the per-frame tracking system. Textfield and search bar now keep focus while typing across frames.

- **Bug Fixes**
  - Register text fields via iui_register_textfield in iui_textfield_with_selection and iui_search_bar_ex.
  - Auto-focus and register search->query in iui_search_view_begin.
  - Prevent ctx->focused_edit from being cleared for active inputs.

<sup>Written for commit 41c4b76a05d5929b8dd4b9fa5d67299e3c06fdbc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

